### PR TITLE
make sure to filter parameters if filtering q in order to avoid index…

### DIFF
--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -455,7 +455,7 @@ class EnsembleDistribution:
         p.loc[computable] = 0
         for name, parameters in self.parameters.items():
             w = weights.loc[computable, name]
-            p += w * self.distribution_map[name](parameters=parameters).pdf(x.loc[computable])
+            p += w * self.distribution_map[name](parameters=parameters.loc[computable]).pdf(x.loc[computable])
 
         if single_val:
             p = p.iloc[0]
@@ -476,7 +476,7 @@ class EnsembleDistribution:
         x.loc[computable] = 0
         for name, parameters in self.parameters.items():
             w = weights.loc[computable, name]
-            x += w * self.distribution_map[name](parameters=parameters).ppf(q.loc[computable])
+            x += w * self.distribution_map[name](parameters=parameters.loc[computable]).ppf(q.loc[computable])
 
         if single_val:
             x = x.iloc[0]

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -455,7 +455,8 @@ class EnsembleDistribution:
         p.loc[computable] = 0
         for name, parameters in self.parameters.items():
             w = weights.loc[computable, name]
-            p += w * self.distribution_map[name](parameters=parameters.loc[computable]).pdf(x.loc[computable])
+            params = parameters.loc[computable] if len(parameters) > 1 else parameters
+            p += w * self.distribution_map[name](parameters=params).pdf(x.loc[computable])
 
         if single_val:
             p = p.iloc[0]
@@ -476,7 +477,8 @@ class EnsembleDistribution:
         x.loc[computable] = 0
         for name, parameters in self.parameters.items():
             w = weights.loc[computable, name]
-            x += w * self.distribution_map[name](parameters=parameters.loc[computable]).ppf(q.loc[computable])
+            params = parameters.loc[computable] if len(parameters) > 1 else parameters
+            x += w * self.distribution_map[name](parameters=params).ppf(q.loc[computable])
 
         if single_val:
             x = x.iloc[0]


### PR DESCRIPTION
this was breaking eggs because q/x was being filtered to computable but weights wasn't so it was hitting that error we added about indices not being identical