### PR TITLE
fix bug that gave missing cols error when it should have been extra

### DIFF
--- a/src/risk_distributions/formatting.py
+++ b/src/risk_distributions/formatting.py
@@ -117,7 +117,8 @@ def format_data_frame(data: pd.DataFrame, required_columns: List[Any], measure: 
     if data.empty:
         raise ValueError(f"No data provided for {measure.lower()}.")
 
-    if not np.all(data.columns.isin(required_columns)):
+    missing_cols = set(required_columns).difference(data.columns)
+    if missing_cols:
         raise ValueError(f"{measure} data provided is missing "
                          f"columns {set(required_columns).difference(data.columns)}.")
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from risk_distributions.formatting import cast_to_series
+from risk_distributions.formatting import cast_to_series, format_data_frame
 
 
 valid_inputs = (np.array([1]), pd.Series([1]), [1], (1,), 1)
@@ -90,3 +90,13 @@ def test_cast_to_series_mismatched_length(reference, other):
 
     with pytest.raises(ValueError, match='same number of values'):
         cast_to_series(other, reference)
+
+
+@pytest.mark.parametrize('data_columns, required_columns, match', [(['a', 'b', 'c'], ['b', 'c'], 'extra columns'),
+                                                                   (['a', 'b'], ['a', 'b', 'c'], 'missing columns'),
+                                                                   ([], ['a'], 'No data')])
+def test_format_data_frame(data_columns, required_columns, match):
+    data = pd.DataFrame(data={c: [1] for c in data_columns}, index=[0])
+
+    with pytest.raises(ValueError, match=match):
+        format_data_frame(data, required_columns, measure='test')


### PR DESCRIPTION
just a little bug that annoyed me in working with distributions for the hypertension mgt model - it was giving me a missing columns error and in the error message said I was missing an empty set of columns because it should have actually been an extra columns error