### PR TITLE
Address Pandas 2.1 FutureWarnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,6 @@
-**2.0.11 - 12/27/22**
+**2.0.12 - 09/15/23**
+
+ - Address Pandas 2.1 FutureWarnings
 
  - Update PR template
  - Modify codeowners

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 
  - Address Pandas 2.1 FutureWarnings
 
+**2.0.11 - 12/27/22**
+
  - Update PR template
  - Modify codeowners
  - Update CI and setup to build python 3.7-3.10

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**2.0.12 - 09/15/23**
+**2.0.12 - 09/26/23**
 
  - Address Pandas 2.1 FutureWarnings
 

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -47,7 +47,7 @@ class BaseDistribution:
 
             mean, sd = cast_to_series(mean, sd)
 
-            parameters = pd.DataFrame(0, columns=required_parameters, index=mean.index)
+            parameters = pd.DataFrame(0.0, columns=required_parameters, index=mean.index)
 
             computable = cls.computable_parameter_index(mean, sd)
             parameters.loc[computable, ["x_min", "x_max"]] = cls.compute_min_max(


### PR DESCRIPTION
## Address Pandas 2.1 FutureWarnings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: [MIC-4545](https://jira.ihme.washington.edu/browse/MIC-4545)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Pandas 2.1.0 features a new deprecation (at least, one that we must address here):
https://pandas.pydata.org/docs/dev/whatsnew/v2.1.0.html#deprecations

It is silent upcasting of datatypes, for which we just need to define pd.Series(0, ...) or DataFrame with a value of 0.0 instead, so it starts out with float data

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tested in US CVD and FutureWarnings are no longer present
