### PR TITLE
Mic-4384/Notify workflow fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,22 @@ jobs:
       - name: Doctest
         run: |
           make doctest -C docs/
+      - name: Send mail
+        # Notify when cron job fails
+        if: (github.event_name == 'schedule' && failure())
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,22 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*
+      - name: Send mail
+        # Notify when cron job fails
+        if: failure()
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan


### PR DESCRIPTION
## Mic-4384/notify-workflow-failure

### Sends email notifications when schedule or deploy workflows fail
- *Category*: CI
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4384

### Changes and notes
-sends email notification when schedule or deploy workflows fail

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

