### PR TITLE
Fix broken build on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,11 @@ version: 2
 
 # Configure the python version and environment construction run before
 # docs are built.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 python:
-  version: 3.8
   install:
       # This runs pip install .[docs] from the project root.
     - method: pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.0.16 - 01/29/24**
+
+ - Fix broken readthedocs build
+
 **2.0.15 - 01/09/24**
 
  - Update PyPI to 2FA with trusted publisher


### PR DESCRIPTION
## Fix broken build on readthedocs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4861

### Changes and notes
- fix broken build on readthdocs 

### Testing
Need to merge to main, but [this same change](https://github.com/ihmeuw/vivarium/pull/385)  fixed the build in vivarium
