### PR TITLE
drop python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     uses: 
       ihmeuw/vivarium_build_utils/.github/workflows/build.yml@main
     with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**2.1.0 - 11/07/24**
+
+ - Drop support for Python 3.9
+ - Modernize type hinting
+
 **2.0.17 - 09/17/24**
 
 - Pin Sphinx below 8.0

--- a/src/risk_distributions/formatting.py
+++ b/src/risk_distributions/formatting.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, List, Tuple, TypeVar, Union
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 
-Parameter = TypeVar("Parameter", np.ndarray, pd.Series, List, Tuple, int, float)
+Parameter = TypeVar("Parameter", np.ndarray, pd.Series, list, tuple, int, float)
 Parameters = TypeVar(
-    "Parameters", np.ndarray, pd.Series, pd.DataFrame, List, Tuple, Dict[str, Parameter]
+    "Parameters", np.ndarray, pd.Series, pd.DataFrame, list, tuple, dict[str, Parameter]
 )
 
 
@@ -42,7 +42,7 @@ def cast_to_series(mean: Parameter, sd: Parameter) -> (pd.Series, pd.Series):
     return mean, sd
 
 
-def format_data(data: Parameters, required_columns: List[Any], measure: str) -> pd.DataFrame:
+def format_data(data: Parameters, required_columns: list[Any], measure: str) -> pd.DataFrame:
     """Formats parameter data into a dataframe."""
     if isinstance(data, np.ndarray):
         data = format_array(data, required_columns, measure)
@@ -58,7 +58,7 @@ def format_data(data: Parameters, required_columns: List[Any], measure: str) -> 
     return data
 
 
-def format_array(data: np.ndarray, required_columns: List[any], measure: str) -> pd.DataFrame:
+def format_array(data: np.ndarray, required_columns: list[Any], measure: str) -> pd.DataFrame:
     """Transforms 1d and 2d arrays into dataframes with columns for the
     parameters and (possibly) rows for each parameter variation."""
     if not data.size:
@@ -111,7 +111,7 @@ def format_array(data: np.ndarray, required_columns: List[any], measure: str) ->
     return data
 
 
-def format_series(data: pd.Series, required_columns: List[Any], measure: str) -> pd.DataFrame:
+def format_series(data: pd.Series, required_columns: list[Any], measure: str) -> pd.DataFrame:
     """Transforms series data into dataframes with columns for the
     parameters and (possibly) rows for each parameter variation."""
     if data.empty:
@@ -134,7 +134,7 @@ def format_series(data: pd.Series, required_columns: List[Any], measure: str) ->
 
 
 def format_data_frame(
-    data: pd.DataFrame, required_columns: List[Any], measure: str
+    data: pd.DataFrame, required_columns: list[Any], measure: str
 ) -> pd.DataFrame:
     """Checks that input data provided as a dataframe is properly formatted."""
     if data.empty:
@@ -155,7 +155,7 @@ def format_data_frame(
 
 
 def format_list_like(
-    data: Union[List, Tuple], required_columns: List[Any], measure: str
+    data: list | tuple, required_columns: list[Any], measure: str
 ) -> pd.DataFrame:
     """Transforms 1d and 2d lists or tuples into dataframes with columns for
     the parameters and (possibly) rows for each parameter variation."""
@@ -164,7 +164,7 @@ def format_list_like(
 
 
 def format_dict(
-    data: Dict[str, Parameter], required_columns: List[Any], measure: str
+    data: dict[str, Parameter], required_columns: list[Any], measure: str
 ) -> pd.DataFrame:
     """Transform dictionaries with scalar or list-like values into dataframes
     with columns for the parameters and (possibly) rows for each parameter

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -113,9 +113,7 @@ class BaseDistribution:
         """
         return data
 
-    def pdf(
-        self, x: pd.Series | np.ndarray | float | int
-    ) -> pd.Series | np.ndarray | float:
+    def pdf(self, x: pd.Series | np.ndarray | float | int) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -150,9 +148,7 @@ class BaseDistribution:
             p = p.values
         return p
 
-    def ppf(
-        self, q: pd.Series | np.ndarray | float | int
-    ) -> pd.Series | np.ndarray | float:
+    def ppf(self, q: pd.Series | np.ndarray | float | int) -> pd.Series | np.ndarray | float:
         single_val = isinstance(q, (float, int))
         values_only = isinstance(q, np.ndarray)
 
@@ -187,9 +183,7 @@ class BaseDistribution:
             x = x.values
         return x
 
-    def cdf(
-        self, x: pd.Series | np.ndarray | float | int
-    ) -> pd.Series | np.ndarray | float:
+    def cdf(self, x: pd.Series | np.ndarray | float | int) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -597,9 +591,7 @@ class EnsembleDistribution:
 
         return weights, params
 
-    def pdf(
-        self, x: pd.Series | np.ndarray | float | int
-    ) -> pd.Series | np.ndarray | float:
+    def pdf(self, x: pd.Series | np.ndarray | float | int) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -673,9 +665,7 @@ class EnsembleDistribution:
             x = x.values
         return x
 
-    def cdf(
-        self, x: pd.Series | np.ndarray | float | int
-    ) -> pd.Series | np.ndarray | float:
+    def cdf(self, x: pd.Series | np.ndarray | float | int) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, Dict, Tuple, Union
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd
@@ -114,8 +114,8 @@ class BaseDistribution:
         return data
 
     def pdf(
-        self, x: Union[pd.Series, np.ndarray, float, int]
-    ) -> Union[pd.Series, np.ndarray, float]:
+        self, x: pd.Series | np.ndarray | float | int
+    ) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -151,8 +151,8 @@ class BaseDistribution:
         return p
 
     def ppf(
-        self, q: Union[pd.Series, np.ndarray, float, int]
-    ) -> Union[pd.Series, np.ndarray, float]:
+        self, q: pd.Series | np.ndarray | float | int
+    ) -> pd.Series | np.ndarray | float:
         single_val = isinstance(q, (float, int))
         values_only = isinstance(q, np.ndarray)
 
@@ -188,8 +188,8 @@ class BaseDistribution:
         return x
 
     def cdf(
-        self, x: Union[pd.Series, np.ndarray, float, int]
-    ) -> Union[pd.Series, np.ndarray, float]:
+        self, x: pd.Series | np.ndarray | float | int
+    ) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -558,7 +558,7 @@ class EnsembleDistribution:
     def __init__(
         self,
         weights: Parameters,
-        parameters: Dict[str, Parameters] = None,
+        parameters: dict[str, Parameters] = None,
         mean: Parameter = None,
         sd: Parameter = None,
     ):
@@ -571,7 +571,7 @@ class EnsembleDistribution:
         parameters: Parameters = None,
         mean: Parameter = None,
         sd: Parameter = None,
-    ) -> Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]:
+    ) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
         weights = format_data(weights, list(cls._distribution_map.keys()), "weights")
 
         params = {}
@@ -598,8 +598,8 @@ class EnsembleDistribution:
         return weights, params
 
     def pdf(
-        self, x: Union[pd.Series, np.ndarray, float, int]
-    ) -> Union[pd.Series, np.ndarray, float]:
+        self, x: pd.Series | np.ndarray | float | int
+    ) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -626,9 +626,9 @@ class EnsembleDistribution:
 
     def ppf(
         self,
-        q: Union[pd.Series, np.ndarray, float, int],
-        q_dist: Union[pd.Series, np.ndarray, float, int],
-    ) -> Union[pd.Series, np.ndarray, float]:
+        q: pd.Series | np.ndarray | float | int,
+        q_dist: pd.Series | np.ndarray | float | int,
+    ) -> pd.Series | np.ndarray | float:
         """Quantile function using 2 propensities.
 
         Parameters
@@ -674,8 +674,8 @@ class EnsembleDistribution:
         return x
 
     def cdf(
-        self, x: Union[pd.Series, np.ndarray, float, int]
-    ) -> Union[pd.Series, np.ndarray, float]:
+        self, x: pd.Series | np.ndarray | float | int
+    ) -> pd.Series | np.ndarray | float:
         single_val = isinstance(x, (float, int))
         values_only = isinstance(x, np.ndarray)
 
@@ -712,7 +712,7 @@ class NonConvergenceError(Exception):
 
 def _get_optimization_result(
     mean: pd.Series, sd: pd.Series, func: Callable, initial_func: Callable
-) -> Tuple:
+) -> tuple:
     """Finds the shape parameters of distributions which generates mean/sd close to actual mean/sd.
 
     Parameters


### PR DESCRIPTION
## drop Python 3.9 support

### Description
- *Category*: CI
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5493

### Changes and notes
Drop support for Python 3.9 and modernize type hinting.

### Testing
Tests pass.
