### PR TITLE
Fix Bug in Mirrored Distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.1 - 11/26/24**
+
+ - Fix bug in MirroredGamma and MirroredGumbel CDFs.
+
 **2.1.0 - 11/07/24**
 
  - Drop support for Python 3.9

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -437,7 +437,7 @@ class MirroredGumbel(BaseDistribution):
         )
         if process_type in ["pdf_preprocess", "cdf_preprocess"]:
             value = x_max - data
-        elif process_type == "ppf_preprocess":
+        elif process_type in ["ppf_preprocess", "cdf_postprocess"]:
             # noinspection PyTypeChecker
             value = 1 - data
         elif process_type == "ppf_postprocess":
@@ -471,7 +471,7 @@ class MirroredGamma(BaseDistribution):
         )
         if process_type in ["pdf_preprocess", "cdf_preprocess"]:
             value = x_max - data
-        elif process_type == "ppf_preprocess":
+        elif process_type in ["ppf_preprocess", "cdf_postprocess"]:
             # noinspection PyTypeChecker
             value = 1 - data
         elif process_type == "ppf_postprocess":

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -57,13 +57,13 @@ class BaseDistribution:
             # transforming them into RuntimeWarnings. This gets noisy in our logs.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
-                parameters.loc[
-                    computable, list(cls.expected_parameters)
-                ] = cls._get_parameters(
-                    mean.loc[computable],
-                    sd.loc[computable],
-                    parameters.loc[computable, "x_min"],
-                    parameters.loc[computable, "x_max"],
+                parameters.loc[computable, list(cls.expected_parameters)] = (
+                    cls._get_parameters(
+                        mean.loc[computable],
+                        sd.loc[computable],
+                        parameters.loc[computable, "x_min"],
+                        parameters.loc[computable, "x_max"],
+                    )
                 )
 
         return parameters

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -57,13 +57,13 @@ class BaseDistribution:
             # transforming them into RuntimeWarnings. This gets noisy in our logs.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
-                parameters.loc[computable, list(cls.expected_parameters)] = (
-                    cls._get_parameters(
-                        mean.loc[computable],
-                        sd.loc[computable],
-                        parameters.loc[computable, "x_min"],
-                        parameters.loc[computable, "x_max"],
-                    )
+                parameters.loc[
+                    computable, list(cls.expected_parameters)
+                ] = cls._get_parameters(
+                    mean.loc[computable],
+                    sd.loc[computable],
+                    parameters.loc[computable, "x_min"],
+                    parameters.loc[computable, "x_max"],
                 )
 
         return parameters

--- a/tests/test_risk_distributions.py
+++ b/tests/test_risk_distributions.py
@@ -34,6 +34,7 @@ def test_cdf(test_data, distribution):
     test_distribution = distribution(mean=mean, sd=sd)
     x_min, x_max = test_distribution.parameters.x_min, test_distribution.parameters.x_max
 
+    # TODO MIC-5595: Find and fix places where inputs are mutated in-place
     test_x = test_distribution.ppf(test_q.copy())
 
     #  ppf can generate the value outside of the range(x_min, x_max) which will make nan if we use it in cdf.

--- a/tests/test_risk_distributions.py
+++ b/tests/test_risk_distributions.py
@@ -15,10 +15,9 @@ distributions = [
     risk_distributions.Normal,
     risk_distributions.Weibull,
     risk_distributions.Beta,
+    risk_distributions.MirroredGumbel,
+    risk_distributions.MirroredGamma,
 ]
-
-# FIXME: The following distributions break without updates to the processing functions
-# risk_distributions.MirroredGumbel, risk_distributions.MirroredGamma,
 
 
 @pytest.fixture
@@ -35,7 +34,7 @@ def test_cdf(test_data, distribution):
     test_distribution = distribution(mean=mean, sd=sd)
     x_min, x_max = test_distribution.parameters.x_min, test_distribution.parameters.x_max
 
-    test_x = test_distribution.ppf(test_q)
+    test_x = test_distribution.ppf(test_q.copy())
 
     #  ppf can generate the value outside of the range(x_min, x_max) which will make nan if we use it in cdf.
     #  thus we only test the value within our range(x_min, x_max)


### PR DESCRIPTION
## Fix Bug in Mirrored Distributions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5168

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The wrapper for ppf has both a pre-processing and post-processing step to flip the range value, then flip the domain value. cdf was only flipping the domain value, but not the range value.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Checked against original notebook
cdfs now are sensible
![image](https://github.com/user-attachments/assets/3f0fe18c-20a6-4092-8b94-be0b28e2b352)
pdf unchanged
![image](https://github.com/user-attachments/assets/6773aeea-d4ea-4150-8c82-438fd0dc87d4)
![image](https://github.com/user-attachments/assets/e5817927-78d0-4bd8-a588-cae35efc3dfa)
cdf calculated through ppf still works
![image](https://github.com/user-attachments/assets/9a89a926-6ebf-40f9-a0a1-c9ae15aaeae4)



