### PR TITLE
Remove Mutable State Bug

### DIFF
--- a/src/risk_distributions/formatting.py
+++ b/src/risk_distributions/formatting.py
@@ -191,9 +191,9 @@ def format_call_data(call_data, parameters):
                 "If providing call_data as a series it must "
                 "be indexed consistently with the parameter data."
             )
-        call_data = pd.Series(call_data, index=parameters.index)
+        call_data = pd.Series(call_data, index=parameters.index, copy=True)
     else:
-        call_data = pd.Series(call_data)
+        call_data = pd.Series(call_data, copy=True)
         parameters = parameters.reindex(call_data.index, method="nearest")
 
     return call_data, parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 
@@ -17,3 +19,12 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+def assert_equal(a, b):
+    if isinstance(a, (pd.Series, pd.DataFrame)):
+        assert a.equals(b)
+    elif isinstance(a, np.ndarray):
+        assert np.allclose(a, b)
+    else:
+        assert a == b

--- a/tests/test_risk_distributions.py
+++ b/tests/test_risk_distributions.py
@@ -71,7 +71,6 @@ def test_cdf(test_data, distribution):
     test_distribution = distribution(mean=mean, sd=sd)
     x_min, x_max = test_distribution.parameters.x_min, test_distribution.parameters.x_max
 
-    # TODO MIC-5595: Find and fix places where inputs are mutated in-place
     test_x = test_distribution.ppf(test_q)
 
     #  ppf can generate the value outside of the range(x_min, x_max) which will make nan if we use it in cdf.

--- a/tests/test_risk_distributions.py
+++ b/tests/test_risk_distributions.py
@@ -1,6 +1,9 @@
+import copy
+
 import numpy as np
 import pandas as pd
 import pytest
+from conftest import assert_equal
 
 from risk_distributions import risk_distributions
 
@@ -28,6 +31,40 @@ def test_data():
     return test_mean, test_sd, test_q
 
 
+parameters = [
+    (1, 1),
+    (np.array([1, 2, 3]), np.array([1, 2, 3])),
+    (pd.Series([1, 2, 3]), pd.Series([1, 2, 3])),
+    ([1, 2, 3], [1, 2, 3]),
+    ((1, 2, 3), (1, 2, 3)),
+]
+
+test_qs = [0.1, 4, np.array([0.1, 0.2, 0.3]), pd.Series([0.1, 0.2, 0.3])]
+
+
+@pytest.mark.parametrize("distribution", distributions)
+@pytest.mark.parametrize("mean, sd", parameters)
+@pytest.mark.parametrize("test_q", test_qs)
+def test_no_state_mutations(mean, sd, test_q, distribution):
+    expected_mean, expected_sd, expected_q = copy.deepcopy((mean, sd, test_q))
+    test_distribution = distribution(mean=mean, sd=sd)
+
+    test_distribution.pdf(test_q)
+    assert_equal(mean, expected_mean)
+    assert_equal(sd, expected_sd)
+    assert_equal(test_q, expected_q)
+
+    test_distribution.ppf(test_q)
+    assert_equal(mean, expected_mean)
+    assert_equal(sd, expected_sd)
+    assert_equal(test_q, expected_q)
+
+    test_distribution.cdf(test_q)
+    assert_equal(mean, expected_mean)
+    assert_equal(sd, expected_sd)
+    assert_equal(test_q, expected_q)
+
+
 @pytest.mark.parametrize("distribution", distributions)
 def test_cdf(test_data, distribution):
     mean, sd, test_q = test_data
@@ -35,7 +72,7 @@ def test_cdf(test_data, distribution):
     x_min, x_max = test_distribution.parameters.x_min, test_distribution.parameters.x_max
 
     # TODO MIC-5595: Find and fix places where inputs are mutated in-place
-    test_x = test_distribution.ppf(test_q.copy())
+    test_x = test_distribution.ppf(test_q)
 
     #  ppf can generate the value outside of the range(x_min, x_max) which will make nan if we use it in cdf.
     #  thus we only test the value within our range(x_min, x_max)


### PR DESCRIPTION
## Remove Mutable State Bug
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5595

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Risk Distributions had a bug where you could mutate the state of an underlying pandas series, so it would hide issues when you used that same input series as a check against some output. I added copy=True to the `format_call_data` method in `formatting.py`, then went ahead and just added copy=True to all series / dataframe instantiations in `formatting.py` just to be safe.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Added tests first, verified they failed, then verified they now pass.
