### PR TITLE
Fix mirror point bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.4 - 05/05/26**
+
+ - Bugfix: Persist mirror_point in parameters so MirroredDistribution can be instantiated without mean/sd
+
 **2.3.3 - 04/15/26**
 
  - Add computability bound argument to Distribution class

--- a/src/risk_distributions/risk_distributions.py
+++ b/src/risk_distributions/risk_distributions.py
@@ -20,6 +20,7 @@ class BaseDistribution:
 
     distribution = None
     expected_parameters = ()
+    _extra_parameters = ()
 
     def __init__(
         self,
@@ -40,7 +41,9 @@ class BaseDistribution:
         computability_bound: float = 0.001,
     ) -> pd.DataFrame:
         required_parameters = list(
-            cls.expected_parameters + ("computability_min", "computability_max")
+            cls.expected_parameters
+            + cls._extra_parameters
+            + ("computability_min", "computability_max")
         )
         if parameters is not None:
             if not (mean is None and sd is None):
@@ -68,7 +71,7 @@ class BaseDistribution:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
                 parameters.loc[
-                    computable, list(cls.expected_parameters)
+                    computable, list(cls.expected_parameters + cls._extra_parameters)
                 ] = cls._get_parameters(
                     mean.loc[computable], sd.loc[computable], computability_bound
                 )
@@ -231,6 +234,8 @@ class BaseDistribution:
 
 
 class MirroredDistribution(BaseDistribution):
+    _extra_parameters = ("mirror_point",)
+
     def __init__(
         self,
         parameters: Parameters = None,
@@ -239,9 +244,12 @@ class MirroredDistribution(BaseDistribution):
         computability_bound: float = 0.001,
     ):
         super().__init__(parameters, mean, sd, computability_bound)
-        # Match index of mean/sd to parameters for ease of use in mirror point calculation
-        mean, sd = cast_to_series(mean, sd)
-        self.mirror_point = self.compute_mirror_point(mean, sd, computability_bound)
+        # When called from EnsembleDistribution.ppf, only parameters are provided.
+        if mean is not None and sd is not None:
+            mean, sd = cast_to_series(mean, sd)
+            self.mirror_point = self.compute_mirror_point(mean, sd, computability_bound)
+        else:
+            self.mirror_point = self.parameters["mirror_point"]
 
     @staticmethod
     def compute_mirror_point(
@@ -476,12 +484,13 @@ class MirroredGumbel(MirroredDistribution):
     def _get_parameters(
         mean: pd.Series, sd: pd.Series, computability_bound: float
     ) -> pd.DataFrame:
+        # Persist mirror_point in params so it's available when re-instantiated with only parameters.
+        mirror_point = MirroredGumbel.compute_mirror_point(mean, sd, computability_bound)
         params = pd.DataFrame(
             {
-                "loc": MirroredGumbel.compute_mirror_point(mean, sd, computability_bound)
-                - mean
-                - (np.euler_gamma * np.sqrt(6) / np.pi * sd),
+                "loc": mirror_point - mean - (np.euler_gamma * np.sqrt(6) / np.pi * sd),
                 "scale": np.sqrt(6) / np.pi * sd,
+                "mirror_point": mirror_point,
             },
             index=mean.index,
         )
@@ -516,6 +525,7 @@ class MirroredGamma(MirroredDistribution):
             {
                 "a": ((mirror_point - mean) / sd) ** 2,
                 "scale": sd**2 / (mirror_point - mean),
+                "mirror_point": mirror_point,
             },
             index=mean.index,
         )

--- a/tests/test_risk_distributions.py
+++ b/tests/test_risk_distributions.py
@@ -203,3 +203,18 @@ def test_individual_distribution_get_params(i, mean, sd):
     for dist in expected.keys():
         for params in expected[dist].keys():
             assert np.isclose(expected[dist][params][i], generated[dist][params])
+
+
+@pytest.mark.parametrize(
+    "distribution",
+    [risk_distributions.MirroredGumbel, risk_distributions.MirroredGamma],
+)
+def test_mirrored_distribution_from_parameters_only(distribution):
+    """Regression test: MirroredDistribution must be instantiable with only parameters."""
+    mean = pd.Series([10, 20, 30])
+    sd = pd.Series([1, 3, 5])
+    params = distribution.get_parameters(mean=mean, sd=sd)
+    dist = distribution(parameters=params)
+    assert not dist.mirror_point.isna().any()
+    result = dist.ppf(pd.Series([0.5, 0.5, 0.5]))
+    assert not np.isnan(result).any()


### PR DESCRIPTION
## Albrja/bugifx/mirror-point

### Fix bug in params columns with mirror point
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7074

### Changes and notes
-fixes mirror point bug in Mirror distribution instantiation from EnsembleDistribution

### Testing
Successfully ran parallel simulation

### Code reviewer
PR Review: Persist mirror_point in MirroredDistribution parameters
Summary
This PR fixes a TypeError: object of type 'NoneType' has no len() that occurs when EnsembleDistribution.ppf/pdf/cdf instantiate MirroredGumbel or MirroredGamma with only parameters (no mean/sd). The fix introduces an _extra_parameters class attribute hook on BaseDistribution, sets it to ("mirror_point",) on MirroredDistribution, persists mirror_point in the DataFrames returned by _get_parameters, and conditionally reads it back in __init__.

Design
_extra_parameters is the right abstraction — it cleanly separates scipy kwargs (expected_parameters) from persisted metadata without requiring a full method override. The separation is enforced at risk_distributions.py:155 and risk_distributions.py:182 where only expected_parameters are passed to scipy.

MirroredDistribution.__init__ conditional is unnecessary — by the time __init__ runs, super().__init__() has already called get_parameters() → _get_parameters() → compute_mirror_point(), and the result lives in self.parameters["mirror_point"]. The if mean is not None branch recomputes the same value. Simplify to:


def __init__(self, parameters=None, mean=None, sd=None, computability_bound=0.001):    super().__init__(parameters, mean, sd, computability_bound)    self.mirror_point = self.parameters["mirror_point"]
This eliminates the redundant computation, removes the branching, and works for both instantiation paths.

EnsembleDistribution.get_expected_parameters is inconsistent — at risk_distributions.py:667-673, it returns expected_parameters + ["x_min", "x_max"] but doesn't include _extra_parameters. After this PR, mirror_point is a real column for mgamma/mgumbel parameters, but this method won't report it. Downstream code relying on this method to know the full column set will miss mirror_point:


@classmethoddef get_expected_parameters(cls, distribution_name: str) -> list[str]:    dist = cls._distribution_map[distribution_name]    return [*dist.expected_parameters, *dist._extra_parameters, "x_min", "x_max"]
parameters.sum(axis=1) != 0 heuristic — the computable row filter at risk_distributions.py:136 now sums mirror_point along with the scipy parameters. This is safe today (mirror_point is always positive for computable rows, zero for non-computable rows from the DataFrame initialization), but it's worth noting as a fragile assumption if future _extra_parameters could be negative.

Maintainability
_extra_parameters needs a comment — at risk_distributions.py:23, it's unclear how this differs from expected_parameters. Add:


# Parameters stored in the DataFrame but not passed to the scipy distribution._extra_parameters = ()
No enforcement that _get_parameters returns _extra_parameters columns — if a future subclass declares _extra_parameters but forgets to include those columns in _get_parameters, the DataFrame will silently contain 0.0 values (from pre-initialization). Consider an assertion after _get_parameters returns.

Missing matching comment on MirroredGamma._get_parameters — MirroredGumbel has the explanatory comment but MirroredGamma does not. Add the same # Persist mirror_point in params... comment for consistency.

DRY
Identical process() in MirroredGumbel and MirroredGamma — these are character-for-character identical (risk_distributions.py:500-510 and risk_distributions.py:535-545). Move process() up to MirroredDistribution. (Pre-existing issue, but visible in the changed code.)

Redundant compute_mirror_point call — as noted in Design #2, the conditional branch recomputes mirror_point rather than reading the already-stored value.

Tests
No test covers the exact bug scenario — no test instantiates MirroredGamma/MirroredGumbel with only parameters= (the path that caused the TypeError). A regression test is essential:


@pytest.mark.parametrize("distribution", [MirroredGamma, MirroredGumbel])def test_mirrored_distribution_from_parameters_only(distribution):    mean, sd = pd.Series([10, 20, 30]), pd.Series([1, 3, 5])    params = distribution.get_parameters(mean=mean, sd=sd)    dist = distribution(parameters=params)    result = dist.ppf(pd.Series([0.5, 0.5, 0.5]))    assert not np.isnan(result).any()
No end-to-end EnsembleDistribution.ppf/pdf/cdf test — the test file only exercises weight formatting. The integration path that triggers the bug is untested.

No roundtrip consistency test — verifying that distribution(parameters=dist.parameters).ppf(q) equals dist.ppf(q) would catch any divergence between the two instantiation paths.

Documentation
CHANGELOG entry is clear and accurate.
Add a one-line comment above _extra_parameters in BaseDistribution explaining its distinction from expected_parameters.
Add the persistence comment to MirroredGamma._get_parameters to match MirroredGumbel.
Functionality
The fix is correct for the reported bug — MirroredDistribution(parameters=params) will no longer call cast_to_series(None, None).
get_expected_parameters omits mirror_point — any downstream code using this method (e.g., in vivarium_public_health) to determine the full parameter column set will not know about mirror_point. This could cause issues if downstream code filters or selects columns based on this method's output.
Minor Nits
The comment at line 248 references a specific caller (EnsembleDistribution.ppf) rather than describing the invariant. If the conditional is kept, reword to: # mirror_point is available in self.parameters regardless of instantiation path.
Overall
The fix correctly solves the bug with a minimal, well-designed extension point (_extra_parameters). The main action items are:

Simplify __init__ to unconditionally read from self.parameters["mirror_point"] (removes redundancy and branching)
Update get_expected_parameters to include _extra_parameters
Add regression tests for the parameters-only instantiation path and EnsembleDistribution end-to-end
Add a comment above _extra_parameters on BaseDistribution